### PR TITLE
Compile to RDF

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -75,6 +75,7 @@ MooseX::Singleton  = 0.04
 Promises           = 0.01
 String::Escape     = 2010.002
 Term::ReadLine     = 0
+RDF::Query         = 2.912
 RDF::RDFa::Parser  = 1.097
 RDF::Trine         = 1.011
 Readonly           = 0

--- a/lib/Dallycot/AST/All.pm
+++ b/lib/Dallycot/AST/All.pm
@@ -15,6 +15,19 @@ sub new {
   return bless \@exprs => $class;
 }
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  #
+  # node -> expression_set -> [ ... ]
+  #
+  return $model -> apply(
+    $model -> meta_uri('loc:all-true'),
+    [ @$self ],
+    {}
+  );
+}
+
 sub simplify {
   my ($self) = @_;
 

--- a/lib/Dallycot/AST/Any.pm
+++ b/lib/Dallycot/AST/Any.pm
@@ -14,6 +14,27 @@ sub simplify {
   return bless [ map { $_->simplify } @$self ] => __PACKAGE__;
 }
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  #
+  # node -> expression_set -> [ ... ]
+  #
+  return $model -> apply(
+    $model -> meta_uri('loc:any-true'),
+    [ @$self ],
+    {}
+  );
+  # my $bnode = $model->bnode();
+  #
+  # $model -> add_type($bnode, 'loc:AnyTrue');
+  #
+  # foreach my $expr (@$self) {
+  #   $model -> add_expression($bnode, $expr);
+  # }
+  # return $bnode;
+}
+
 sub process_loop {
   my ( $self, $engine, $d, @expressions ) = @_;
 

--- a/lib/Dallycot/AST/Apply.pm
+++ b/lib/Dallycot/AST/Apply.pm
@@ -25,6 +25,19 @@ sub new {
   return bless [ $expression, $bindings, $options ] => $class;
 }
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  #
+  # node -> expression_set -> [ ... ]
+  #
+  return $model -> apply(
+    $self -> [0],
+    $self -> [1],
+    $self -> [2]
+  )
+}
+
 sub simplify {
   my ($self) = @_;
 

--- a/lib/Dallycot/AST/BuildFilter.pm
+++ b/lib/Dallycot/AST/BuildFilter.pm
@@ -10,8 +10,27 @@ use parent 'Dallycot::AST';
 
 use Carp qw(croak);
 use Dallycot::Util qw(maybe_promise);
-use List::Util qw(all any);
-use Promises qw(deferred collect);
+
+use List::Util     qw(all any);
+use Promises       qw(deferred collect);
+
+sub to_rdf {
+  my($self, $model) = @_;
+
+  return $model -> apply(
+    $model -> meta_uri('loc:build-filter'),
+    [ @$self ],
+    {}
+  );
+
+  # my $bnode = $model -> bnode;
+  # $model -> add_type($bnode, 'loc:Filter');
+  # $model -> add_list($bnode, 'loc:expressions',
+  #   map { $_ -> to_rdf($model) } @{$self}
+  # );
+  #
+  # return $bnode;
+}
 
 sub execute {
   my ( $self, $engine ) = @_;

--- a/lib/Dallycot/AST/BuildList.pm
+++ b/lib/Dallycot/AST/BuildList.pm
@@ -12,6 +12,25 @@ use experimental qw(switch);
 
 use Promises qw(deferred);
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  return $model -> apply(
+    $model -> meta_uri('loc:build-list'),
+    [ @$self ],
+    {}
+  );
+  # my $bnode = $model -> bnode;
+  # $model -> add_type($bnode, 'loc:List');
+  # if(@$self) {
+  #   $model -> add_list($bnode, 'loc:expressions',
+  #     map { $_ -> to_rdf($model) } @$self
+  #   );
+  # }
+
+  # return $bnode;
+}
+
 sub execute {
   my ( $self, $engine ) = @_;
 

--- a/lib/Dallycot/AST/BuildMap.pm
+++ b/lib/Dallycot/AST/BuildMap.pm
@@ -13,6 +13,16 @@ use Dallycot::Util qw(maybe_promise);
 use List::Util qw(all any);
 use Promises qw(deferred collect);
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  return $model -> apply(
+    $model -> meta_uri('loc:build-map'),
+    [ @$self ],
+    {}
+  );
+}
+
 sub execute {
   my ( $self, $engine ) = @_;
 

--- a/lib/Dallycot/AST/BuildRange.pm
+++ b/lib/Dallycot/AST/BuildRange.pm
@@ -8,6 +8,32 @@ use warnings;
 use utf8;
 use parent 'Dallycot::AST';
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  if(@$self > 1) {
+    return $model -> apply(
+      $model -> meta_uri('loc:range'),
+      [
+        $self->[0], $self -> [1]
+      ]
+    );
+  }
+  else {
+    return $model -> apply(
+      $model -> meta_uri('loc:upfrom'),
+      [ $self -> [0] ]
+    );
+  }
+  # my $bnode = $model -> bnode;
+  # $model -> add_type($bnode, 'loc:Range');
+  # $model -> add_first($bnode, $self->[0]);
+  # if(@$self > 1) {
+  #   $model -> add_last($bnode, $self->[1]);
+  # }
+  # return $bnode;
+}
+
 sub execute {
   my ( $self, $engine ) = @_;
 

--- a/lib/Dallycot/AST/BuildSet.pm
+++ b/lib/Dallycot/AST/BuildSet.pm
@@ -8,6 +8,23 @@ use warnings;
 use utf8;
 use parent 'Dallycot::AST';
 
+sub to_rdf {
+  my ( $self, $model ) = @_;
+
+  return $model -> apply(
+    $model -> meta_uri('loc:build-set'),
+    [ @$self ],
+    {}
+  );
+  # my $bnode = $model -> bnode;
+  # $model -> add_type($bnode, 'loc:Set');
+  # $model -> add_list($bnode, 'loc:expressions',
+  #   map { $_ -> to_rdf($model) } @{$self}
+  # );
+  #
+  # return $bnode;
+}
+
 sub execute {
   my ( $self, $engine ) = @_;
 

--- a/lib/Dallycot/AST/BuildVector.pm
+++ b/lib/Dallycot/AST/BuildVector.pm
@@ -8,6 +8,21 @@ use warnings;
 use utf8;
 use parent 'Dallycot::AST';
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  return $model -> apply(
+    $model -> meta_uri('loc:build-vector'),
+    [ @$self ],
+    {}
+  );
+  # my $bnode = $model -> bnode;
+  # $model -> add_type($bnode, 'loc:Vector');
+  # $model -> add_list($bnode, 'loc:expressions',
+  #   map { $_ -> to_rdf($model) } @$self
+  # );
+}
+
 sub execute {
   my ( $self, $engine ) = @_;
 

--- a/lib/Dallycot/AST/Compose.pm
+++ b/lib/Dallycot/AST/Compose.pm
@@ -10,6 +10,23 @@ use parent 'Dallycot::AST';
 
 use Promises qw(deferred);
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  return $model -> apply(
+    $model -> meta_uri('loc:compose'),
+    [ @$self ],
+    {}
+  );
+  # my $bnode = $model -> bnode;
+  # $model -> add_type($bnode, 'loc:Composition');
+  # $model -> add_list($bnode, 'loc:expressions',
+  #   map { $_ -> to_rdf($model) } @{$self}
+  # );
+  #
+  # return $bnode;
+}
+
 sub execute {
   my ( $self, $engine ) = @_;
 

--- a/lib/Dallycot/AST/Condition.pm
+++ b/lib/Dallycot/AST/Condition.pm
@@ -8,6 +8,34 @@ use warnings;
 use utf8;
 use parent 'Dallycot::AST::LoopBase';
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  my $bnode = $model -> bnode;
+  $model -> add_type($bnode, 'loc:GuardedSequence');
+  $model -> add_list($bnode, 'loc:expressions',
+    map {
+      $self->_case_to_rdf($model, $_)
+    } @$self
+  );
+
+  return $bnode;
+}
+
+sub _case_to_rdf {
+  my($self, $model, $cond) = @_;
+
+  my $expr = $cond->[1]->to_rdf($model);
+  if(defined $cond->[0]) {
+    $expr = $model -> add_connection(
+      $expr,
+      'loc:guard',
+      $cond->[0]->to_rdf($model)
+    );
+  }
+  return $expr;
+}
+
 sub child_nodes {
   my ($self) = @_;
 

--- a/lib/Dallycot/AST/Cons.pm
+++ b/lib/Dallycot/AST/Cons.pm
@@ -10,6 +10,16 @@ use parent 'Dallycot::AST';
 
 use Promises qw(deferred);
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  return $model -> apply(
+    $model -> meta_uri('loc:consolidate'),
+    [ @$self ],
+    {}
+  );
+}
+
 sub execute {
   my ( $self, $engine ) = @_;
 

--- a/lib/Dallycot/AST/Decreasing.pm
+++ b/lib/Dallycot/AST/Decreasing.pm
@@ -14,6 +14,15 @@ sub to_string {
   return join( " >= ", map { $_->to_string } @{$self} );
 }
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  return $model -> apply(
+    $model -> meta_uri('loc:all-decreasing'),
+    [ @$self ]
+  );
+}
+
 sub compare {
   my ( $self, $engine, $left_value, $right_value ) = @_;
 

--- a/lib/Dallycot/AST/Defined.pm
+++ b/lib/Dallycot/AST/Defined.pm
@@ -16,6 +16,20 @@ sub to_string {
   return "?(" . ( $self->[0]->to_string ) . ")";
 }
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  return $model -> apply(
+    $model -> meta_uri('loc:not-empty'),
+    [ $self->[0] ],
+    {}
+  );
+  # my $bnode = $model -> bnode;
+  # $model -> add_type($bnode, 'loc:NotEmpty');
+  # $model -> add_expression($self -> [0]);
+  # return $bnode;
+}
+
 sub execute {
   my ( $self, $engine ) = @_;
 

--- a/lib/Dallycot/AST/Equality.pm
+++ b/lib/Dallycot/AST/Equality.pm
@@ -14,6 +14,15 @@ sub to_string {
   return join( " = ", map { $_->to_string } @{$self} );
 }
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  return $model -> apply(
+    $model -> meta_uri('loc:all-equal'),
+    [ @$self ]
+  );
+}
+
 sub compare {
   my ( $self, $engine, $left_value, $right_value ) = @_;
 

--- a/lib/Dallycot/AST/Expr.pm
+++ b/lib/Dallycot/AST/Expr.pm
@@ -16,6 +16,10 @@ sub to_json {
 
 sub to_string { return "" }
 
+sub to_rdf {
+
+}
+
 sub execute {
   my ( $self, $engine ) = @_;
 

--- a/lib/Dallycot/AST/FullPlaceholder.pm
+++ b/lib/Dallycot/AST/FullPlaceholder.pm
@@ -10,6 +10,14 @@ use parent 'Dallycot::AST';
 
 sub to_string { return "___" }
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  my $bnode = $model -> bnode;
+  $model -> add_type($bnode, 'loc:FullPlaceholder');
+  return $bnode;
+}
+
 sub new {
   return bless [] => __PACKAGE__;
 }

--- a/lib/Dallycot/AST/Head.pm
+++ b/lib/Dallycot/AST/Head.pm
@@ -16,6 +16,15 @@ sub to_string {
   return $self->[0]->to_string . "'";
 }
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  my $bnode = $model -> bnode;
+  $model -> add_type($bnode, 'loc:Head');
+  $model -> add_expression($bnode, $self -> [0]);
+  return $bnode;
+}
+
 sub execute {
   my ( $self, $engine ) = @_;
 

--- a/lib/Dallycot/AST/Identity.pm
+++ b/lib/Dallycot/AST/Identity.pm
@@ -16,6 +16,12 @@ sub to_string {
   return $self->[0]->to_string;
 }
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  return $self->[0]->to_rdf($model);
+}
+
 sub execute {
   my ( $self, $engine ) = @_;
 

--- a/lib/Dallycot/AST/Increasing.pm
+++ b/lib/Dallycot/AST/Increasing.pm
@@ -13,6 +13,22 @@ sub to_string {
   return join( " <= ", map { $_->to_string } @{$self} );
 }
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  return $model -> apply(
+    $model -> meta_uri('loc:all-increasing'),
+    [ @$self ]
+  );
+  # my $bnode = $model->bnode;
+  # $model -> add_type($bnode, 'loc:Increasing');
+  #
+  # $model -> add_list($bnode, 'loc:expressions',
+  #   map { $_ -> to_rdf($model) } @$self
+  # );
+  # return $bnode;
+}
+
 sub compare {
   my ( $self, $engine, $left_value, $right_value ) = @_;
 

--- a/lib/Dallycot/AST/Index.pm
+++ b/lib/Dallycot/AST/Index.pm
@@ -10,6 +10,28 @@ use parent 'Dallycot::AST';
 
 use Promises qw(deferred);
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  my @exprs = @$self;
+
+  my $node = $model -> apply(
+    $model -> meta_uri('loc:index'),
+    [ $exprs[0], $exprs[1] ]
+  );
+
+  shift @exprs; shift @exprs;
+
+  while(@exprs) {
+    $node = $model -> apply(
+      $model -> meta_uri('loc:index'),
+      [ $node, shift @exprs ]
+    );
+  }
+  
+  return $node;
+}
+
 sub execute {
   my ( $self, $engine ) = @_;
 

--- a/lib/Dallycot/AST/Invert.pm
+++ b/lib/Dallycot/AST/Invert.pm
@@ -15,6 +15,17 @@ sub new {
   return bless [$expr] => $class;
 }
 
+
+sub to_rdf {
+  my($self, $model) = @_;
+
+  return $model -> apply(
+    $model -> meta_uri('loc:invert'),
+    [ $self->[0] ],
+    {}
+  );
+}
+
 sub execute {
   my ( $self, $engine ) = @_;
 

--- a/lib/Dallycot/AST/Lambda.pm
+++ b/lib/Dallycot/AST/Lambda.pm
@@ -28,6 +28,39 @@ sub new {
   return bless [ $expr, $bindings, $bindings_with_defaults, $options ] => $class;
 }
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  my $bnode = $model -> bnode;
+  $model -> add_type($bnode, 'loc:Algorithm');
+  $model -> add_expression($bnode, $self -> [$EXPRESSION]);
+  $model -> add_list(
+    $bnode, 'loc:bindings',
+    (map { $self -> _binding_rdf($model, $_) } @{$self->[$BINDINGS]}),
+    (map { $self -> _binding_rdf($model, @$_) } @{$self->[$BINDINGS_WITH_DEFAULTS]})
+  );
+  foreach my $opt(keys %{$self->[$OPTIONS]}) {
+    $model -> add_option(
+      $bnode,
+      $opt,
+      $self->[$OPTIONS]->{$opt}->to_rdf($model)
+    );
+  }
+  return $bnode;
+}
+
+sub _binding_rdf {
+  my($self, $model, $label, $expr) = @_;
+
+  my $bnode = $model -> bnode;
+  $model -> add_type($bnode, 'loc:Binding');
+  $model -> add_label($bnode, $label);
+  if(defined $expr) {
+    $model -> add_expression($bnode, $expr);
+  }
+  return $bnode;
+}
+
 sub child_nodes {
   my ($self) = @_;
   return $self->[$EXPRESSION],

--- a/lib/Dallycot/AST/Modulus.pm
+++ b/lib/Dallycot/AST/Modulus.pm
@@ -15,6 +15,23 @@ sub to_string {
   return join( " mod ", map { $_->to_string } @$self );
 }
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  return $model -> apply(
+    $model -> meta_uri('loc:modulus'),
+    [ @$self ],
+    {}
+  );
+  # my $bnode = $model->bnode;
+  # $model -> add_type($bnode, 'loc:Modulus');
+  #
+  # $model -> add_list($bnode, 'loc:expressions',
+  #   map { $_ -> to_rdf($model) } @$self
+  # );
+  # return $bnode;
+}
+
 sub execute {
   my ( $self, $engine ) = @_;
 

--- a/lib/Dallycot/AST/Negation.pm
+++ b/lib/Dallycot/AST/Negation.pm
@@ -14,6 +14,20 @@ sub to_string {
   return "-" . $self->[0]->to_string;
 }
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  return $model -> apply(
+    $model -> meta_uri('loc:negate'),
+    [ $self->[0] ],
+    {}
+  );
+  # my $bnode = $model -> bnode;
+  # $model -> add_type($bnode, 'loc:Negation');
+  # $model -> add_expression($self -> [0]);
+  # return $bnode;
+}
+
 sub execute {
   my ( $self, $engine ) = @_;
 

--- a/lib/Dallycot/AST/Placeholder.pm
+++ b/lib/Dallycot/AST/Placeholder.pm
@@ -10,6 +10,14 @@ use parent 'Dallycot::AST';
 
 sub to_string { return "_" }
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  my $bnode = $model -> bnode;
+  $model -> add_type($bnode, 'loc:Placeholder');
+  return $bnode;
+}
+
 sub new {
   return bless [] => __PACKAGE__;
 }

--- a/lib/Dallycot/AST/Product.pm
+++ b/lib/Dallycot/AST/Product.pm
@@ -18,6 +18,26 @@ sub to_string {
   return "(" . join( "*", map { $_->to_string } @{$self} ) . ")";
 }
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  #
+  # node -> expression_set -> [ ... ]
+  #
+  return $model -> apply(
+    $model -> meta_uri('loc:product'),
+    [ @$self ],
+    {}
+  );
+  # my $bnode = $model->bnode;
+  # $model -> add_type($bnode, 'loc:Product');
+  #
+  # foreach my $expr (@$self) {
+  #   $model -> add_expression($bnode, $expr);
+  # }
+  # return $bnode;
+}
+
 sub execute {
   my ( $self, $engine ) = @_;
 

--- a/lib/Dallycot/AST/Reciprocal.pm
+++ b/lib/Dallycot/AST/Reciprocal.pm
@@ -18,6 +18,20 @@ sub to_string {
   return "1/(" . $self->[0]->to_string . ")";
 }
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  return $model -> apply(
+    $model -> meta_uri('loc:reciprocal'),
+    [ $self->[0] ],
+    {}
+  );
+  # my $bnode = $model -> bnode;
+  # $model -> add_type($bnode, 'loc:Reciprocal');
+  # $model -> add_expression($self -> [0]);
+  # return $bnode;
+}
+
 sub execute {
   my ( $self, $engine ) = @_;
 

--- a/lib/Dallycot/AST/StrictlyDecreasing.pm
+++ b/lib/Dallycot/AST/StrictlyDecreasing.pm
@@ -14,6 +14,22 @@ sub to_string {
   return join( " > ", map { $_->to_string } @{$self} );
 }
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  return $model -> apply(
+    $model -> meta_uri('loc:all-strictly-decreasing'),
+    [ @$self ]
+  );
+  # my $bnode = $model->bnode;
+  # $model -> add_type($bnode, 'loc:StrictlyDecreasing');
+  #
+  # $model -> add_list($bnode, 'loc:expressions',
+  # map { $_ -> to_rdf($model) } @$self
+  # );
+  # return $bnode;
+}
+
 sub compare {
   my ( $self, $engine, $left_value, $right_value ) = @_;
 

--- a/lib/Dallycot/AST/StrictlyIncreasing.pm
+++ b/lib/Dallycot/AST/StrictlyIncreasing.pm
@@ -14,6 +14,22 @@ sub to_string {
   return join( " < ", map { $_->to_string } @{$self} );
 }
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  return $model -> apply(
+    $model -> meta_uri('loc:all-strictly-increasing'),
+    [ @$self ]
+  );
+  # my $bnode = $model->bnode;
+  # $model -> add_type($bnode, 'loc:StrictlyIncreasing');
+  #
+  # $model -> add_list($bnode, 'loc:expressions',
+  # map { $_ -> to_rdf($model) } @$self
+  # );
+  # return $bnode;
+}
+
 sub compare {
   my ( $self, $engine, $left_value, $right_value ) = @_;
 

--- a/lib/Dallycot/AST/Sum.pm
+++ b/lib/Dallycot/AST/Sum.pm
@@ -18,6 +18,26 @@ sub to_string {
   return "(" . join( "+", map { $_->to_string } @{$self} ) . ")";
 }
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  #
+  # node -> expression_set -> [ ... ]
+  #
+  return $model -> apply(
+    $model -> meta_uri('loc:sum'),
+    [ @$self ],
+    {}
+  );
+  # my $bnode = $model->bnode;
+  # $model -> add_type($bnode, 'loc:Sum');
+  #
+  # foreach my $expr (@$self) {
+  #   $model -> add_expression($bnode, $expr);
+  # }
+  # return $bnode;
+}
+
 sub execute {
   my ( $self, $engine ) = @_;
 

--- a/lib/Dallycot/AST/Tail.pm
+++ b/lib/Dallycot/AST/Tail.pm
@@ -15,6 +15,15 @@ sub to_string {
   return $self->[0]->to_string . '...';
 }
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  my $bnode = $model -> bnode;
+  $model -> add_type($bnode, 'loc:Tail');
+  $model -> add_expression($bnode, $self -> [0]);
+  return $bnode;
+}
+
 sub execute {
   my ( $self, $engine ) = @_;
 

--- a/lib/Dallycot/AST/Unique.pm
+++ b/lib/Dallycot/AST/Unique.pm
@@ -15,6 +15,18 @@ sub to_string {
   return join( " <> ", map { $_->to_string } @{$self} );
 }
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  #
+  # node -> expression_set -> [ ... ]
+  #
+  return $model -> apply(
+    $model -> meta_uri('loc:all-unique'),
+    [ @$self ]
+  );
+}
+
 sub execute {
   my ( $self, $engine ) = @_;
 

--- a/lib/Dallycot/AST/Zip.pm
+++ b/lib/Dallycot/AST/Zip.pm
@@ -18,6 +18,23 @@ sub to_string {
   return '(' . join( ' Z ', map { $_->to_string } @{$self} ) . ')';
 }
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  return $model -> apply(
+    $model -> meta_uri('loc:zip'),
+    [ @$self ],
+    {}
+  );
+  # my $bnode = $model->bnode;
+  # $model -> add_type($bnode, 'loc:Zip');
+  #
+  # $model -> add_list($bnode, 'loc:expressions',
+  #   map { $_ -> to_rdf($model) } @$self
+  # );
+  # return $bnode;
+}
+
 sub execute {
   my ( $self, $engine ) = @_;
 

--- a/lib/Dallycot/Channel.pm
+++ b/lib/Dallycot/Channel.pm
@@ -27,4 +27,6 @@ sub receive_data {
   croak "receive() is not implemented for $class";
 }
 
+__PACKAGE__ -> meta -> make_immutable;
+
 1;

--- a/lib/Dallycot/Channel/Terminal.pm
+++ b/lib/Dallycot/Channel/Terminal.pm
@@ -79,4 +79,6 @@ sub add_history {
   return;
 }
 
+__PACKAGE__ -> meta -> make_immutable;
+
 1;

--- a/lib/Dallycot/Compiler.pm
+++ b/lib/Dallycot/Compiler.pm
@@ -1,0 +1,382 @@
+package Dallycot::Compiler;
+
+use Moose;
+
+use RDF::Trine;
+use RDF::Query;
+use Data::UUID;
+use Carp qw(croak);
+use Storable qw(dclone);
+use Dallycot::Model;
+use Dallycot::Registry;
+use Dallycot::Resolver;
+
+has root => (
+  is => 'rw'
+);
+
+has model => (
+  isa => 'Dallycot::Model',
+  is => 'ro',
+  default => sub {
+    Dallycot::Model -> new
+  },
+  handles => [qw/
+    as_turtle
+    as_ntriples
+    as_tsv
+    as_xml
+    as_dot
+  /]
+);
+
+has _prefixes => (
+  isa => 'RDF::Trine::NamespaceMap',
+  is => 'ro',
+  default => sub {
+    RDF::Trine::NamespaceMap->new({
+      'loc' => 'http://www.dallycot.net/ns/loc/1.0#',
+      'rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+      'rdfs' => 'http://www.w3.org/2000/01/rdf-schema#',
+      'xsd' => 'http://www.w3.org/2001/XMLSchema#',
+    })
+  }
+);
+
+has prefixes => (
+  isa => 'RDF::Trine::NamespaceMap',
+  is => 'ro',
+  default => sub {
+    RDF::Trine::NamespaceMap->new
+  },
+  lazy => 1,
+  predicate => 'has_prefixes'
+);
+
+has parent => (
+  isa => __PACKAGE__,
+  is => 'ro',
+  predicate => 'has_parent',
+  required => 0
+);
+
+has symbols => (
+  isa => 'HashRef',
+  is => 'ro',
+  default => sub { +{} }
+);
+
+has namespace_search_path => (
+  isa => 'ArrayRef',
+  is => 'ro',
+  default => sub { [] }
+);
+
+sub child_model {
+  my($self, %info) = @_;
+
+  return $self -> new(
+    parent => $self,
+    _prefixes => $self -> _prefixes,
+    model => $self -> model,
+    prefixes => dclone($self -> prefixes),
+    namespace_search_path => [ @{$self -> namespace_search_path} ],
+    %info
+  );
+}
+
+sub add_search_path {
+  my($self, @paths) = @_;
+
+  my $cv = AnyEvent -> condvar;
+
+  Dallycot::Registry->instance->register_used_namespaces(@paths)->done(sub {
+    push @{$self -> namespace_search_path}, @paths;
+    $cv -> send();
+  }, sub {
+    $cv -> croak(@_);
+  });
+  $cv -> recv;
+}
+
+sub add_symbol {
+  my($self, $symbol, $uri) = @_;
+
+  if($self->symbols->{$symbol}) {
+    croak "$symbol may only be defined once in a scope\n";
+  }
+
+  $self -> symbols -> {$symbol} = $uri;
+}
+
+sub fetch_symbol {
+  my($self, $symbol) = @_;
+
+  return unless defined $symbol;
+  if($self->symbols->{$symbol}) {
+    return $self->symbols->{$symbol};
+  }
+
+  if($self -> has_parent) {
+    my $val = $self->parent->fetch_symbol($symbol);
+    return $val if $val;
+  }
+
+  # now look through search path
+  my $registry = Dallycot::Registry->instance;
+  if($registry->has_assignment( $self -> namespace_search_path, $symbol )) {
+    my $uri = $registry->get_assignment_uri( $self -> namespace_search_path, $symbol);
+    return RDF::Trine::Node::Resource->new($uri) if $uri;
+  }
+}
+
+sub add_namespace_mapping {
+  my($self, $ns, $href) = @_;
+
+  $self -> prefixes -> add_mapping($ns, $href);
+}
+
+sub compile {
+  my($self, @exprs) = @_;
+
+  my $expr;
+
+  if(@exprs > 1) {
+    $expr = Dallycot::AST::Sequence->new(@exprs);
+  }
+  else {
+    $expr = $exprs[0];
+  }
+
+  my $root = $expr->to_rdf($self);
+  $self->root($root);
+  return $root;
+}
+
+
+sub uri {
+  my($self, $prefixed) = @_;
+
+  if($self -> has_prefixes) {
+    my $uri = $self -> prefixes -> uri($prefixed);
+    return $uri if defined $uri;
+  }
+
+  if($self -> has_parent) {
+    return $self -> parent -> uri($prefixed);
+  }
+
+  return $prefixed;
+}
+
+sub meta_uri {
+  my($self, $prefixed) = @_;
+
+  return $self -> _prefixes -> uri($prefixed);
+}
+
+sub add_type {
+  my($self, $node, $type) = @_;
+
+  $self -> model -> add_statement(
+    RDF::Trine::Statement -> new(
+      $node,
+      $self -> _prefixes -> rdf->type,
+      $self -> _prefixes -> uri($type)
+    )
+  );
+}
+
+sub add_expression {
+  my($self, $node, $expr) = @_;
+
+  return unless defined $expr;
+
+  $expr = $expr -> to_rdf($self) unless $expr -> isa('RDF::Trine::Node');
+
+  $self -> model -> add_statement(
+    RDF::Trine::Statement -> new(
+      $node,
+      $self -> _prefixes -> uri('loc:expression'),
+      $expr
+    )
+  );
+}
+
+sub add_connection {
+  my($self, $node, $prop, $object) = @_;
+
+  return unless defined $object;
+
+  if($node -> is_literal) {
+    # mint a node that points to the literal
+    my $bnode = $self -> bnode;
+    $self -> add_connection($bnode, 'rdf:value', $node);
+    $node = $bnode;
+  }
+
+  $self->model -> add_statement(
+    RDF::Trine::Statement->new(
+      $node,
+      $self -> _prefixes -> uri($prop),
+      $object
+    )
+  );
+
+  return $node;
+}
+
+sub add_label {
+  my($self, $node, $label) = @_;
+
+  return unless defined $label;
+
+  $self->model -> add_statement(
+    RDF::Trine::Statement -> new(
+      $node,
+      $self -> _prefixes -> uri('rdfs:label'),
+      RDF::Trine::Node::Literal->new($label, '')
+    )
+  );
+}
+
+sub add_option {
+  my($self, $node, $label, $expr) = @_;
+
+  return unless defined $label && defined $expr;
+
+  my $opt_bnode = $self -> bnode;
+  $self->model->add_statement(
+    RDF::Trine::Statement -> new(
+      $node,
+      $self->_prefixes->uri('loc:option'),
+      $opt_bnode
+    )
+  );
+  $self -> add_type($opt_bnode, 'loc:Option');
+  $self -> add_label($opt_bnode, $label);
+  $self -> add_expression($opt_bnode, $expr);
+}
+
+sub add_list {
+  my($self, $node, $prop, @items) = @_;
+  my $list_node = $self -> model -> add_list(@items);
+  $self -> model -> add_statement(
+    RDF::Trine::Statement->new(
+      $node,
+      $self -> _prefixes -> uri($prop),
+      $list_node
+    )
+  );
+}
+
+sub add_first {
+  my($self, $node, $expr) = @_;
+
+  return unless defined $expr;
+
+  $self -> model -> add_statement(
+    RDF::Trine::Statement -> new(
+      $node,
+      $self -> _prefixes -> uri('loc:first'),
+      $expr -> to_rdf($self)
+    )
+  );
+}
+
+sub add_last {
+  my($self, $node, $expr) = @_;
+
+  return unless defined $expr;
+
+  $self -> model -> add_statement(
+    RDF::Trine::Statement -> new(
+      $node,
+      $self -> _prefixes -> uri('loc:last'),
+      $expr -> to_rdf($self)
+    )
+  );
+}
+
+sub apply {
+  my($self, $expression, $bindings, $options) = @_;
+
+  my $bnode = $self->bnode();
+
+  $self -> add_type($bnode, 'loc:Application');
+
+  # $self -> add_expression($bnode, $expression);
+  $expression = $expression -> to_rdf($self) unless $expression -> isa('RDF::Trine::Node');
+  $self -> model -> add_statement(
+    RDF::Trine::Statement->new(
+      $bnode,
+      $self -> _prefixes -> uri('loc:algorithm'),
+      $expression
+    )
+  );
+
+  $self -> add_list($bnode, 'loc:target',
+    map { $_ -> isa('RDF::Query::Node') ? $_ : $_ -> to_rdf($self) } @$bindings
+  ) if $bindings && @$bindings;
+
+  foreach my $opt (keys %{$options||{}}) {
+    $self -> add_option($bnode, $opt, $options->{$opt});
+  }
+
+  return $bnode;
+}
+
+sub integer {
+  my($self, $int) = @_;
+
+  return RDF::Trine::Node::Literal->new($int, '', $self->_prefixes->uri('xsd:integer'));
+}
+
+sub string {
+  my($self, $value, $lang) = @_;
+
+  if($lang) {
+    return RDF::Trine::Node::Literal->new($value, $lang);
+  }
+  else {
+    return RDF::Trine::Node::Literal->new($value, '', $self->_prefixes->uri('xsd:string'));
+  }
+}
+
+sub list {
+  my($self, @items) = @_;
+
+  my $bnode = $self -> model -> add_list(@items);
+
+  return $bnode;
+}
+
+sub list_with_promise {
+  my($self, @items) = @_;
+
+  my $promise = pop @items;
+
+  my $node = $self -> model -> add_list(@items);
+
+  # now to traverse the list to the end and replace the tail with the promise
+  my $root = $node;
+  my @next;
+
+  while(@next = $self -> model -> objects($root, $self -> meta_uri('rdf:rest'), undef, type => 'node')) {
+    last if $next[0] eq $self -> meta_uri('rdf:nil');
+    $root = $next[0];
+  }
+  return $node;
+}
+
+my $uuid_generator = Data::UUID -> new;
+
+sub bnode {
+  my($self) = @_;
+
+  return RDF::Trine::Node::Blank -> new($uuid_generator->to_string($uuid_generator->create));
+}
+
+__PACKAGE__ -> meta -> make_immutable;
+
+1;

--- a/lib/Dallycot/Compiler.pm
+++ b/lib/Dallycot/Compiler.pm
@@ -316,7 +316,7 @@ sub apply {
   );
 
   $self -> add_list($bnode, 'loc:target',
-    map { $_ -> isa('RDF::Query::Node') ? $_ : $_ -> to_rdf($self) } @$bindings
+    map { $_ -> isa('RDF::Trine::Node') ? $_ : $_ -> to_rdf($self) } @$bindings
   ) if $bindings && @$bindings;
 
   foreach my $opt (keys %{$options||{}}) {

--- a/lib/Dallycot/Library/LOC.pm
+++ b/lib/Dallycot/Library/LOC.pm
@@ -1,0 +1,559 @@
+package Dallycot::Library::LOC;
+
+# ABSTRACT: Core library of useful functions
+
+use strict;
+use warnings;
+
+use utf8;
+
+use Dallycot::Library;
+
+use Promises qw(deferred);
+use List::Util qw(all any);
+use Carp qw(croak);
+use experimental qw(switch);
+
+ns 'http://www.dallycot.net/ns/loc/1.0#';
+
+define 'all-true' => (
+  hold => 1,
+  arity => [0],
+  options => {},
+), sub {
+  my ( $engine, $options, @things ) = @_;
+
+  return $engine->TRUE unless @things;
+
+  my $d = deferred;
+
+  my $process_loop;
+
+  $process_loop = sub {
+    if ( !@things ) {
+      $d->resolve( $engine->TRUE );
+    }
+    else {
+      $engine->execute( shift @things, ['Boolean'] )->done(
+        sub {
+          if ( $_[0]->value ) {
+            $process_loop->();
+          }
+          else {
+            $d->resolve( $engine->FALSE );
+          }
+        },
+        sub {
+          $d->reject(@_);
+        }
+      );
+    };
+
+    return;
+  };
+
+  $process_loop->();
+
+  return $d -> promise;
+};
+
+define 'any-true' => (
+  hold => 1,
+  arity => [0],
+  options => {},
+), sub {
+  my ( $engine, $options, @things ) = @_;
+
+  return $engine->FALSE unless @things;
+
+  my $d = deferred;
+
+  my $process_loop;
+
+  $process_loop = sub {
+    if ( !@things ) {
+      $d->resolve( $engine->TRUE );
+    }
+    else {
+      $engine->execute( shift @things, ['Boolean'] )->done(
+        sub {
+          if ( $_[0]->value ) {
+            $d -> resolve( $engine->TRUE );
+          }
+          else {
+            $process_loop -> ();
+          }
+        },
+        sub {
+          $d->reject(@_);
+        }
+      );
+    }
+
+    return;
+  };
+
+  $process_loop->();
+
+  return $d -> promise;
+};
+
+define 'y-combinator' => '(function) :> function(function, ___)';
+
+define foldl => <<'EOD';
+(
+  folder := y-combinator(
+    (self, pad, function, stream) :> (
+      (?stream) : (
+        next := function(pad, stream');
+        [ next, self(self, next, function, stream...) ]
+      )
+      ( ) : [ ]
+    )
+  );
+  (initial, function, stream) :> (
+    (?stream) : folder(initial, function, stream)
+    (       ) : [ initial ]
+  )
+)
+EOD
+
+define foldl1 => <<'EOD';
+  (function, stream) :> (
+    (?stream) : foldl(stream', function, stream...)
+    (       ) : [ ]
+  )
+EOD
+
+define map => <<'EOD';
+y-combinator(
+  (self, mapper, stream) :> (
+    (?stream) : [ mapper(stream'), self(self, mapper, stream...) ]
+    (       ) : [ ]
+  )
+)
+EOD
+
+define filter => <<'EOD';
+y-combinator(
+  (self, selector, stream) :> (
+    (?stream) : (
+      (selector(stream')) : [ stream', self(self, selector, stream...) ]
+      (                 ) : self(self, selector, stream...)
+    )
+    (       ) : [ ]
+  )
+)
+EOD
+
+define 'build-filter' => (
+  hold => 0,
+  arity => [0],
+  options => {},
+), sub {
+  my ( $engine, $options, @functions ) = @_;
+
+  my $stream = pop @functions;
+  return collect( map { maybe_promise( $_->is_lambda ) } @functions )->then(
+    sub {
+      my @flags = map {@$_} @_;
+      if ( any { !$_ } @flags ) {
+        croak "All but the last term in a filter must be lambdas.";
+      }
+    }
+  )->then(
+    sub {
+      return collect( map { maybe_promise( $_->min_arity ) } @functions )->then(
+        sub {
+          my (@arities) = map {@$_} @_;
+          if ( any { 1 != $_ } @arities ) {
+            croak "All lambdas in a filter must have arity 1.";
+          }
+        }
+      );
+    }
+  )->then(
+    sub {
+      return maybe_promise( $stream->is_lambda )->then(
+        sub {
+          my ($flag) = @_;
+          if ($flag) {
+            return $engine->make_filter( $engine->compose_filters( @functions, $stream ) );
+          }
+          else {
+            return $stream->apply_filter( $engine, $engine->compose_filters(@functions) );
+          }
+        }
+      );
+    }
+  );
+};
+
+define 'build-list' => (
+  hold => 1,
+  arity => [0],
+  options => {},
+), sub {
+  my ( $engine, $options, @expressions ) = @_;
+
+  given ( scalar(@expressions) ) {
+    when (0) {
+      return Dallycot::Value::EmptyStream->new;
+    }
+    when (1) {
+      return $engine->execute( $expressions[0] )->then(
+        sub {
+          my ($result) = @_;
+          Dallycot::Value::Stream->new($result);
+        }
+      );
+    }
+    default {
+      my $last_expr = pop @expressions;
+      my $promise;
+      if ( $last_expr->isa('Dallycot::Value') ) {
+        push @expressions, $last_expr;
+      }
+      else {
+        $promise = $engine->make_lambda($last_expr);
+      }
+      return $engine->collect(@expressions)->then(
+        sub {
+          my (@items) = @_;
+          my $result = Dallycot::Value::Stream->new( ( pop @items ), undef, $promise );
+          while (@items) {
+            $result = Dallycot::Value::Stream->new( ( pop @items ), $result );
+          }
+          $result;
+        }
+      );
+    }
+  }
+};
+
+define 'build-map' => (
+  hold => 0,
+  arity => [0],
+  options => {}
+), sub {
+  my ( $engine, $options, @functions ) = @_;
+  my $stream = pop @functions;
+  return collect( map { maybe_promise( $_->is_lambda ) } @functions )->then(
+    sub {
+      my @flags = map {@$_} @_;
+      if ( any { !$_ } @flags ) {
+        croak "All but the last term in a mapping must be lambdas.";
+      }
+    }
+  )->then(
+    sub {
+      return collect( map { maybe_promise( $_->min_arity ) } @functions )->then(
+        sub {
+          my (@arities) = map {@$_} @_;
+          if ( any { 1 != $_ } @arities ) {
+            croak "All lambdas in a mapping must have arity 1.";
+          }
+        }
+      );
+    }
+  )->then(
+    sub {
+      return maybe_promise( $stream->is_lambda )->then(
+        sub {
+          my ($flag) = @_;
+
+          if ($flag) {
+            return $engine->make_map( $engine->compose_lambdas( @functions, $stream ) );
+          }
+          else {
+            my $transform = $engine->compose_lambdas(@functions);
+
+            return $stream->apply_map( $engine, $transform );
+          }
+        }
+      );
+    }
+  );
+};
+
+define upfrom => <<'EOD';
+y-combinator( (self, n) :> [ n, self(self, n + 1) ] )
+EOD
+
+define range => <<'EOD';
+y-combinator(
+  (self, m, n) :> (
+    (m > n) : [ m, self(self, m - 1, n) ]
+    (m = n) : [ m ]
+    (m < n) : [ m, self(self, m + 1, n) ]
+    (     ) : [ ]
+  )
+)
+EOD
+
+define 'build-set' => (
+  hold => 0,
+  arity => [0],
+  options => {}
+), sub {
+  my( $engine, $options, @things ) = @_;
+
+  return Dallycot::Value::Set->new(@things);
+};
+
+define 'build-vector' => (
+  hold => 0,
+  arity => [0],
+  options => {}
+), sub {
+  my( $engine, $options, @things ) = @_;
+
+  return Dallycot::Value::Vector->new(@things);
+};
+
+define 'compose-functions' => (
+  hold => 0,
+  arity => [0],
+  options => {}
+), sub {
+  my ( $engine, $options, @functions ) = @_;
+
+  return collect( map { maybe_promise( $_->is_lambda ) } @functions )->then(
+    sub {
+      my @flags = map {@$_} @_;
+      if ( any { !$_ } @flags ) {
+        croak "All terms in a function composition must be lambdas";
+      }
+    }
+  )->then(
+    sub {
+      return collect( map { maybe_promise( $_->min_arity ) } @functions )->then(
+        sub {
+          my (@arities) = map {@$_} @_;
+
+          if ( any { 1 != $_ } @arities ) {
+            croak "All lambdas in a function composition must have arity 1";
+          }
+        }
+      );
+    }
+  )->then(
+    sub {
+      return $engine->compose_lambdas(@functions);
+    }
+  );
+};
+
+define consolidate => (
+  hold => 0,
+  arity => [1],
+  options => {},
+), sub {
+  my( $engine, $options, $root, @things) = @_;
+
+  return $root unless @things;
+
+  return $root->prepend(@things);
+};
+
+sub compare (&$@) {
+  my ( $comparator, $engine, @expressions ) = @_;
+
+  my $d = deferred;
+
+  my $process_loop;
+
+  $process_loop = sub {
+    my( $left_value ) = @_;
+
+    if ( !@expressions ) {
+      $d -> resolve( $engine -> TRUE );
+    }
+    else {
+      $engine -> execute( shift @expressions ) -> then(
+        sub {
+          my ($right_value) = @_;
+          $engine->coerce( $left_value, $right_value, [ $left_value->type, $right_value->type ] )->done(
+            sub {
+              my ( $cleft, $cright ) = @_;
+              $comparator->( $cleft, $cright )->done(
+                sub {
+                  if ( $_[0] ) {
+                    $process_loop->( $right_value, @expressions );
+                  }
+                  else {
+                    $d->resolve( $engine->FALSE );
+                  }
+                },
+                sub {
+                  $d->reject(@_);
+                }
+              );
+            },
+            sub {
+              $d -> reject(@_);
+            }
+          );
+        },
+        sub {
+          $d -> reject(@_);
+        }
+      );
+    }
+  };
+
+  $engine->execute( shift @expressions )->done(
+    sub {
+      $process_loop->( $_[0] );
+    },
+    sub {
+      $d->reject(@_);
+    }
+  );
+
+  return $d->promise;
+}
+
+define 'all-decreasing' => (
+  hold => 1,
+  arity => [1],
+  options => {}
+), sub {
+  my ( $engine, $options, @things ) = @_;
+
+  compare {
+    my($a, $b) = @_;
+    $a -> is_greater_or_equal( $engine, $b );
+  } @things;
+};
+
+define 'all-increasing' => (
+  hold => 1,
+  arity => [1],
+  options => {}
+), sub {
+  my ( $engine, $options, @things ) = @_;
+
+  compare {
+    my($a, $b) = @_;
+    $a -> is_less_or_equal( $engine, $b );
+  } @things;
+};
+
+define 'all-strictly-decreasing'  => (
+  hold => 1,
+  arity => [1],
+  options => {}
+), sub {
+  my ( $engine, $options, @things ) = @_;
+
+  compare {
+    my($a, $b) = @_;
+    $a -> is_greater( $engine, $b );
+  } @things;
+};
+
+define 'all-strictly-increasing'  => (
+  hold => 1,
+  arity => [1],
+  options => {}
+), sub {
+  my ( $engine, $options, @things ) = @_;
+
+  compare {
+    my($a, $b) = @_;
+    $a -> is_less( $engine, $b );
+  } @things;
+};
+
+define 'all-equal'  => (
+  hold => 1,
+  arity => [1],
+  options => {}
+), sub {
+  my ( $engine, $options, @things ) = @_;
+
+  compare {
+    my($a, $b) = @_;
+    $a -> is_equal( $engine, $b );
+  } @things;
+};
+
+define 'all-unique' => (
+  hold => 0,
+  arity => [1],
+  options => {}
+), sub {
+  my( $engine, $options, @values ) = @_;
+
+  my @types = map { $_->type } @values;
+  return $engine->coerce( @values, \@types )->then(
+    sub {
+      my (@new_values) = @_;
+
+      # now make sure values are all different
+      my %seen;
+      if(all { !$seen{ $_->id }++ } @new_values) {
+        return $engine->TRUE;
+      }
+      else {
+        return $engine->FALSE;
+      }
+    }
+  );
+};
+
+define 'not-empty' => (
+  hold => 0,
+  arity => 1,
+  options => {}
+), sub {
+  my( $engine, $options, $result ) = @_;
+
+  if ( blessed $result ) {
+    return ( $result->is_defined && !$result->is_empty ? $engine->TRUE : $engine->FALSE );
+  }
+  else {
+    return ( $engine->FALSE );
+  }
+};
+
+define 'execute-list' => <<'EOD';
+(sequence) :> (
+  last(
+    foldl(
+      (),
+      { (#2)() }/2,
+      sequence
+    )
+  )
+)
+EOD
+
+define 'invert' => (
+  hold => 0,
+  arity => 1,
+  options => {}
+), sub {
+  my($engine, $options, $res) = @_;
+
+  if ( $res->isa('Dallycot::Value::Boolean') ) {
+    return Dallycot::Value::Boolean->new( !$res->value );
+  }
+  elsif ( $res->isa('Dallycot::Value::Lambda') ) {
+    return $res -> invert;
+    # return Dallycot::Value::Lambda->new(
+    #   expression             => Dallycot::AST::Invert->new( $res->[0] ),
+    #   bindings               => $res->[1],
+    #   bindings_with_defaults => $res->[2],
+    #   options                => $res->[3],
+    #   closure_environment    => $res->[4],
+    #   closure_namespaces     => $res->[5]
+    # );
+  }
+  else {
+    return Dallycot::Value::Boolean->new( !$res->is_defined );
+  }
+};
+
+1;

--- a/lib/Dallycot/Model.pm
+++ b/lib/Dallycot/Model.pm
@@ -1,0 +1,182 @@
+package Dallycot::Model;
+
+use Moose;
+
+use RDF::Trine;
+use RDF::Trine::Serializer::TSV;
+
+has model => (
+  is => 'ro',
+  isa => 'RDF::Trine::Model',
+  default => sub {
+    RDF::Trine::Model -> new
+  },
+  lazy => 1,
+  handles => [qw/
+    add_statement
+    add_list
+    objects
+  /]
+);
+
+has _prefixes => (
+  isa => 'RDF::Trine::NamespaceMap',
+  is => 'ro',
+  default => sub {
+    RDF::Trine::NamespaceMap->new({
+      'loc' => 'http://www.dallycot.net/ns/loc/1.0#',
+      'rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+      'rdfs' => 'http://www.w3.org/2000/01/rdf-schema#',
+      'xsd' => 'http://www.w3.org/2001/XMLSchema#',
+    })
+  },
+  handles => {qw/
+    expand_uri uri
+  /}
+);
+
+sub run {
+  my($self, $uri) = @_;
+
+  my $loc = 'http://www.dallycot.net/ns/loc/1.0#';
+  my $loc_length = length($loc);
+
+  if(!blessed($uri)) {
+    $uri = RDF::Trine::Node::Resource->new($uri);
+  }
+
+  my @types = map {
+    substr($_, $loc_length)
+  } grep {
+    substr($_, 0, $loc_length) eq $loc
+  } $self -> _types($uri);
+
+  if(@types > 1) {
+    croak $uri->value . " is not a unique linked open code type";
+  }
+  elsif(@types == 1) {
+    my $method = $self -> can("run_".$types[0]);
+
+    if(!$method) {
+      croak(($uri->value // '(nil)') . " is not a valid linked open code type");
+    }
+
+    return $self -> $method($uri);
+  }
+  else {
+    # it is probably a value - so we build out a Perl object to represent it
+
+  }
+}
+
+sub run_Application {
+  my($self, $uri) = @_;
+
+
+}
+
+sub run_Sequence {
+  my($self, $uri) = @_;
+
+  # $uri points to a linked list, but also has a set of assignments that
+  # need to be calculated
+
+}
+
+sub run_GuardedSequence {
+  my($self, $uri) = @_;
+
+}
+
+sub _types {
+  my($self, $uri) = @_;
+
+  map {
+    $_ -> uri_value
+  } $self -> model -> objects(
+    $uri,
+    $self -> expand_uri('rdf:type'),
+    undef,
+    type => 'node'
+  );
+}
+
+sub as_turtle {
+  my($self) = @_;
+
+  my $serializer = RDF::Trine::Serializer::Turtle -> new(
+    namespaces => RDF::Trine::NamespaceMap->new({
+      'loc' => 'http://www.dallycot.net/ns/loc/1.0#',
+      'rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+      'rdfs' => 'http://www.w3.org/2000/01/rdf-schema#',
+      'xsd' => 'http://www.w3.org/2001/XMLSchema#',
+    })
+  );
+  return $serializer -> serialize_model_to_string($self -> model);
+}
+
+sub as_ntriples {
+  my($self) = @_;
+
+  my $serializer = RDF::Trine::Serializer::NTriples::Canonical -> new(
+  );
+  return $serializer -> serialize_model_to_string($self -> model);
+}
+
+sub as_tsv {
+  my($self) = @_;
+
+  my $serializer = RDF::Trine::Serializer::TSV -> new(
+    namespaces => RDF::Trine::NamespaceMap->new({
+      'loc' => 'http://www.dallycot.net/ns/loc/1.0#',
+      'rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+      'rdfs' => 'http://www.w3.org/2000/01/rdf-schema#',
+      'xsd' => 'http://www.w3.org/2001/XMLSchema#',
+    })
+  );
+  return $serializer -> serialize_model_to_string($self -> model);
+}
+
+sub as_xml {
+  my($self) = @_;
+
+  my $serializer = RDF::Trine::Serializer::RDFXML -> new(
+    namespaces => RDF::Trine::NamespaceMap->new({
+      'loc' => 'http://www.dallycot.net/ns/loc/1.0#',
+      'rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+      'rdfs' => 'http://www.w3.org/2000/01/rdf-schema#',
+      'xsd' => 'http://www.w3.org/2001/XMLSchema#',
+    })
+  );
+  return $serializer -> serialize_model_to_string($self -> model);
+}
+
+sub as_dot {
+  my($self) = @_;
+
+  require RDF::Trine::Exporter::GraphViz;
+
+  my $serializer = RDF::Trine::Exporter::GraphViz -> new(
+    namespaces => {
+      'loc' => 'http://www.dallycot.net/ns/loc/1.0#',
+      'rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+      'rdfs' => 'http://www.w3.org/2000/01/rdf-schema#',
+      'xsd' => 'http://www.w3.org/2001/XMLSchema#',
+    },
+    alias => sub {
+      my($url) = @_;
+      return 'nil' if $url eq 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil';
+      return 'a' if $url eq 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+      return 'label' if $url eq 'http://www.w3.org/2000/01/rdf-schema#label';
+      return 'head' if $url eq 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first';
+      return 'tail' if $url eq 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest';
+      return 'value' if $url eq 'http://www.w3.org/1999/02/22-rdf-syntax-ns#value';
+      undef;
+    },
+    root => $self->root->value
+  );
+  return $serializer -> to_string($self -> model);
+}
+
+
+1;

--- a/lib/Dallycot/Processor.pm
+++ b/lib/Dallycot/Processor.pm
@@ -338,7 +338,7 @@ sub make_map {
 
   return $self->execute(
     Dallycot::AST::Apply->new(
-      Dallycot::Value::URI->new('http://www.dallycot.net/ns/core/1.0#map'),
+      Dallycot::Value::URI->new('http://www.dallycot.net/ns/loc/1.0#map'),
       [ $transform, Dallycot::AST::Placeholder->new ], {}
     )
   );
@@ -349,7 +349,7 @@ sub make_filter {
 
   return $self->execute(
     Dallycot::AST::Apply->new(
-      Dallycot::Value::URI->new('http://www.dallycot.net/ns/core/1.0#filter'),
+      Dallycot::Value::URI->new('http://www.dallycot.net/ns/loc/1.0#filter'),
       [ $selector, Dallycot::AST::Placeholder->new ], {}
     )
   );

--- a/lib/Dallycot/Processor/PP.pm
+++ b/lib/Dallycot/Processor/PP.pm
@@ -22,4 +22,6 @@ sub DEMOLISH {
   return;
 }
 
+__PACKAGE__ -> meta -> make_immutable;
+
 1;

--- a/lib/Dallycot/Processor/XS.pm
+++ b/lib/Dallycot/Processor/XS.pm
@@ -15,4 +15,6 @@ require XSLoader;
 
 XSLoader::load( __PACKAGE__, $Dallycot::VERSION );
 
+__PACKAGE__ -> meta -> make_immutable;
+
 1;

--- a/lib/Dallycot/Registry.pm
+++ b/lib/Dallycot/Registry.pm
@@ -84,6 +84,28 @@ sub get_assignment {
   return;
 }
 
+sub get_assignment_uri {
+  my( $self, $namespace, $symbol ) = @_;
+
+  if ( is_ArrayRef($namespace) ) {
+    foreach my $n (@$namespace) {
+      if ( $self->has_assignment( $n, $symbol ) ) {
+        return "$n$symbol";
+      }
+    }
+    return;
+  }
+
+  if ( $self->namespaces->{$namespace} ) {
+    my $ns = $self->namespaces->{$namespace};
+    if ( $ns->has_assignment($symbol) ) {
+      return "$ns$symbol";
+    }
+  }
+
+  return;
+}
+
 sub has_namespace {
   my ( $self, $ns ) = @_;
 
@@ -114,5 +136,7 @@ sub initialize {
 
   return $self;
 }
+
+__PACKAGE__ -> meta -> make_immutable;
 
 1;

--- a/lib/Dallycot/Resolver/Request.pm
+++ b/lib/Dallycot/Resolver/Request.pm
@@ -191,4 +191,6 @@ sub handle_redirect {
   return;
 }
 
+__PACKAGE__ -> meta -> make_immutable;
+
 1;

--- a/lib/Dallycot/Tangle.pm
+++ b/lib/Dallycot/Tangle.pm
@@ -203,4 +203,6 @@ sub header {
   return $self->section_name($name);
 }
 
+__PACKAGE__ -> meta -> make_immutable;
+
 1;

--- a/lib/Dallycot/TextResolver/Request.pm
+++ b/lib/Dallycot/TextResolver/Request.pm
@@ -156,4 +156,6 @@ sub run {
   return $deferred->promise;
 }
 
+__PACKAGE__ -> meta -> make_immutable;
+
 1;

--- a/lib/Dallycot/Value/Boolean.pm
+++ b/lib/Dallycot/Value/Boolean.pm
@@ -21,6 +21,16 @@ sub new {
   return $f ? $TRUE : $FALSE;
 }
 
+sub to_rdf {
+  my( $self, $model ) = @_;
+
+  return RDF::Trine::Node::Literal->new(
+    $self->[0] ? 'true' : 'false',
+    '',
+    $model -> meta_uri('xsd:boolean')
+  );
+}
+
 sub as_text {
   my ($self) = @_;
 

--- a/lib/Dallycot/Value/EmptyStream.pm
+++ b/lib/Dallycot/Value/EmptyStream.pm
@@ -16,6 +16,12 @@ sub new {
   return $INSTANCE ||= bless [] => __PACKAGE__;
 }
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  return $model -> add_list;
+}
+
 sub prepend {
   my ( $self, @things ) = @_;
 

--- a/lib/Dallycot/Value/Lambda.pm
+++ b/lib/Dallycot/Value/Lambda.pm
@@ -63,6 +63,31 @@ sub id {
   return '^^Lambda';
 }
 
+sub to_rdf {
+  my( $self, $parent_model ) = @_;
+
+  my $model = $parent_model -> child_model(
+    namespace_search_path => [ @{$self -> [$CLOSURE_NAMESPACE_PATH]} ],
+    prefixes => RDF::Trine::NamespaceMap->new($self -> [$CLOSURE_NAMESPACES]),
+  );
+
+  my $bnode = $model -> bnode;
+  $model -> add_type($bnode, 'loc:Algorithm');
+  $model -> add_expression($bnode, $self -> [$EXPRESSION]);
+  $model -> add_list(
+    $bnode, 'loc:bindings',
+    (map { $self -> _binding_rdf($model, $_) } @{$self->[$BINDINGS]}),
+    (map { $self -> _binding_rdf($model, @$_) } @{$self->[$BINDINGS_WITH_DEFAULTS]})
+  );
+  foreach my $opt(keys %{$self->[$OPTIONS]}) {
+    $model -> add_option(
+      $bnode,
+      $opt,
+      $self->[$OPTIONS]->{$opt}->to_rdf($model)
+    );
+  }
+}
+
 sub as_text {
   my ($self) = @_;
   my ( $min, $max ) = $self->arity;

--- a/lib/Dallycot/Value/Numeric.pm
+++ b/lib/Dallycot/Value/Numeric.pm
@@ -18,6 +18,41 @@ sub new {
   return bless [ ref($value) ? $value : Math::BigRat->new($value) ] => $class;
 }
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  if($self->[0]->is_int) {
+    return $model -> integer($self -> [0] -> bstr);
+  }
+  elsif($self -> [0] -> is_nan) {
+    my $bnode = $model->bnode;
+    $model -> add_type($bnode, 'loc:NotANumber');
+    return $bnode;
+  }
+  elsif($self -> [0] -> is_inf) {
+    my $bnode = $model -> bnode;
+    $model -> add_type($bnode, 'loc:PositiveInfinity');
+    return $bnode;
+  }
+  elsif($self -> [0] -> is_inf('-')) {
+    my $bnode = $model -> bnode;
+    $model -> add_type($bnode, 'loc:NegativeInifinity');
+    return $bnode;
+  }
+  else {
+    my $bnode = $model -> bnode;
+    $model -> add_type($bnode, 'loc:Rational');
+    my($n, $d) = $self -> [0] -> parts;
+    $model -> add_connection($bnode, 'loc:denominator',
+      $model -> integer($d -> bstr)
+    );
+    $model -> add_connection($bnode, 'loc:numerator',
+      $model -> integer($n->bstr)
+    );
+    return $bnode;
+  }
+}
+
 sub id {
   my ($self) = @_;
   return $self->[0]->bstr . "^^Numeric";

--- a/lib/Dallycot/Value/Stream.pm
+++ b/lib/Dallycot/Value/Stream.pm
@@ -29,6 +29,24 @@ sub is_defined { return 1 }
 
 sub is_empty {return}
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  my @things;
+  my $root = $self;
+  push @things, $root -> [0]->to_rdf($model);
+  while($root -> [1]) {
+    $root = $root->[1];
+    push @things, $root->[0]->to_rdf($model);
+  }
+  if($root -> [2]) {
+    return $model -> list_with_promise(@things, $root->[2]);
+  }
+  else {
+    return $model -> list(@things);
+  }
+}
+
 sub prepend {
   my ( $self, @things ) = @_;
 

--- a/lib/Dallycot/Value/String.pm
+++ b/lib/Dallycot/Value/String.pm
@@ -20,6 +20,12 @@ sub new {
   return bless [ $value // '', $lang // 'en' ] => $class;
 }
 
+sub to_rdf {
+  my ( $self, $model ) = @_;
+
+  return $model -> string( $self -> value, $self -> lang );
+}
+
 sub lang { return shift->[1] }
 
 sub id {

--- a/lib/Dallycot/Value/TripleStore.pm
+++ b/lib/Dallycot/Value/TripleStore.pm
@@ -22,6 +22,12 @@ sub as_text {
   return "Graph($subject in $base_url with $size triples)";
 }
 
+sub to_rdf {
+  my( $self, $model ) = @_;
+
+  return RDF::Trine::Node::Resource->new($self->[1]->as_string);
+}
+
 sub is_defined { return 1 }
 
 sub is_empty {

--- a/lib/Dallycot/Value/URI.pm
+++ b/lib/Dallycot/Value/URI.pm
@@ -25,6 +25,12 @@ sub new {
   return bless [$uri] => $class;
 }
 
+sub to_rdf {
+  my( $self, $model ) = @_;
+
+  return RDF::Trine::Node::Resource->new($self->[0]->as_string);
+}
+
 sub calculate_length {
   my ( $self, $engine ) = @_;
 

--- a/lib/Dallycot/Value/Undefined.pm
+++ b/lib/Dallycot/Value/Undefined.pm
@@ -22,6 +22,12 @@ sub as_text {
   return "(undef)";
 }
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  return $model -> meta_uri('rdf:nil');
+}
+
 sub is_defined {return}
 
 sub is_empty { return 1 }

--- a/lib/Dallycot/Value/Vector.pm
+++ b/lib/Dallycot/Value/Vector.pm
@@ -22,6 +22,12 @@ sub is_empty {
   return @$self == 0;
 }
 
+sub to_rdf {
+  my($self, $model) = @_;
+
+  $model -> list(map { $_ -> to_rdf($model) } @$self);
+}
+
 sub is_defined { return 1 }
 
 sub as_text {

--- a/t/40-compiler.t
+++ b/t/40-compiler.t
@@ -1,0 +1,55 @@
+use lib 't/lib';
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Mojo;
+use AnyEvent;
+use Promises backend => ['AnyEvent'];
+
+use Scalar::Util qw(blessed);
+
+use Dallycot;
+use Dallycot::Compiler;
+use Dallycot::Parser;
+use Dallycot::Processor;
+
+BEGIN {
+  require Dallycot::Library;
+  Dallycot::Library->libraries;
+}
+
+BEGIN { use_ok 'Dallycot::Compiler' };
+
+my $parser = Dallycot::Parser->new;
+
+my $result;
+
+$result = compile(<<'EOD');
+even?(n) :> n mod 2 = 0;
+evens := Y((f, s) :> (
+  (even?(s')) : [ s', f(f, s...) ]
+  (         ) :       f(f, s...)
+))
+EOD
+
+$result = compile(<<'EOD');
+uses "http://www.dallycot.net/ns/core/1.0#";
+uses "http://www.dallycot.net/ns/math/1.0#";
+uses "http://www.dallycot.net/ns/streams/1.0#";
+
+primes[50]
+EOD
+
+done_testing();
+
+sub compile {
+  my($stmt) = @_;
+
+  my $parse = $parser -> parse($stmt);
+
+  my $model = Dallycot::Compiler -> new;
+  my $root = $model -> compile(@$parse);
+  return $model -> as_turtle();
+}


### PR DESCRIPTION
Adds an option to `./bin/dallycot` to output the script compiled to RDF. Dallycot doesn't yet use the RDF/triple-store version internally when executing.